### PR TITLE
Update aglcv3.cbx

### DIFF
--- a/aglcv3.cbx
+++ b/aglcv3.cbx
@@ -15,12 +15,12 @@
 \DeclareNameFormat{surname}{\ifthenelse{\value{listcount}=1}{#1}{}}
 \DeclareNameFormat{firstname}{\ifthenelse{\value{listcount}=1}{#3}{}}
 
-% for surnames
+% for surnames - changed to 'last' 17/01/19
 
 \newbibmacro{author/editor:surname}{%
   \ifthenelse{\ifuseauthor\AND\NOT\ifnameundef{author}}%
-    {\ifuseauthor{\printnames[surname]{author}}{}}%
-    {\ifthenelse{\ifuseeditor\AND\NOT\ifnameundef{editor}}{\printnames[surname]{editor}}{}}}
+    {\ifuseauthor{\printnames[last]{author}}{}}%
+    {\ifthenelse{\ifuseeditor\AND\NOT\ifnameundef{editor}}{\printnames[last]{editor}}{}}}
 
 % for reported cases with a venue
 


### PR DESCRIPTION
Calling \printnames[surname] as the naming convention for fields has changed. Amending lines 22 and 23 from 'surname' to 'last' to match new biblatex naming conventions.